### PR TITLE
Move `poision` to be an optional dependency

### DIFF
--- a/mix.exs
+++ b/mix.exs
@@ -32,7 +32,7 @@ defmodule BencheeJSON.Mixfile do
   defp deps do
     [
       {:benchee,     github: "PragTob/benchee", branch: "master"},
-      {:poison,      ">= 1.4.0"},
+      {:poison,      ">= 1.4.0", optional: true},
       {:excoveralls, "~> 0.6.1", only: :test},
       {:credo,       "~> 0.4",   only: :dev},
       {:ex_doc,      "~> 0.14",  only: :dev},


### PR DESCRIPTION
This will allow Poison to use `benchee_html` for their benchmarks. More
info on this option here:
https://hexdocs.pm/mix/Mix.Tasks.Deps.html#module-dependency-definition-options

Fixes #2 