### PR TITLE
Add memory usage statistics

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -1,29 +1,16 @@
 language: elixir
 elixir:
-  - 1.4.5
-  - 1.5.3
   - 1.6.6
   - 1.7.1
 otp_release:
-  - 19.3
   - 20.3
   - 21.0
-
-matrix:
-  exclude:
-  - elixir: 1.4.5
-    otp_release: 21.0
-  - elixir: 1.5.3
-    otp_release: 21.0
-  - elixir: 1.7.1
-    otp_release: 19.3
-
 before_script:
   - MIX_ENV=test mix compile --warnings-as-errors
   - travis_wait mix dialyzer --plt
 script:
   - mix credo --strict
-  - if [[ "$TRAVIS_ELIXIR_VERSION" == "1.6"* ]]; then mix format --check-formatted; fi
+  - mix format --check-formatted
   - mix dialyzer --halt-exit-status
   - mix coveralls.travis
 after_script:

--- a/test/benchee/formatters/json_integration_test.exs
+++ b/test/benchee/formatters/json_integration_test.exs
@@ -24,26 +24,21 @@ defmodule Benchee.Formatters.JSONIntegrationTest do
 
       assert File.exists?(@file_path)
       content = File.read!(@file_path)
-      decoded = Jason.decode!(content)
+      [list, sleep] = Jason.decode!(content)
 
       assert %{
-               "run_times" => run_times,
-               "memory_usages" => memory_usages,
-               "run_time_statistics" => run_time_statistics,
-               "memory_usage_statistics" => memory_usage_statistics
-             } = decoded
+               "name" => "Sleep",
+               "run_time_statistics" => %{"average" => _, "ips" => _},
+               "run_times" => [run_time | _]
+             } = sleep
 
-      assert map_size(run_times) == 2
-      assert map_size(memory_usages) == 2
-      assert map_size(run_time_statistics) == 2
-      assert map_size(memory_usage_statistics) == 2
+      assert run_time > 10_000_000
 
-      assert %{"average" => _, "ips" => _} = run_time_statistics["Sleep"]
-      assert [head | _] = run_times["Sleep"]
-      assert head >= 0
-
-      assert %{"average" => _, "median" => _} = memory_usage_statistics["List"]
-      assert [376 | _] = memory_usages["List"]
+      assert %{
+               "name" => "List",
+               "memory_usage_statistics" => %{"average" => _, "ips" => _},
+               "memory_usages" => [376 | _]
+             } = list
     end)
   after
     File.rm(@file_path)

--- a/test/benchee/formatters/json_test.exs
+++ b/test/benchee/formatters/json_test.exs
@@ -1,75 +1,10 @@
 defmodule Benchee.Formatters.JSONTest do
-  use ExUnit.Case
+  use ExUnit.Case, async: true
   doctest Benchee.Formatters.JSON
 
-  alias Benchee.{Suite, Benchmark.Scenario, Formatters.JSON}
+  alias Benchee.{Suite, Formatters.JSON}
 
   describe "format/1" do
-    test "includes sort_order" do
-      suite = %Benchee.Suite{
-        scenarios: [
-          %Scenario{
-            job_name: "My Job",
-            run_times: [500],
-            name: "My Job",
-            input_name: "Some Input",
-            input: "Some Input",
-            run_time_statistics: %Benchee.Statistics{
-              average: 500.0,
-              ips: 2000.0,
-              std_dev: 200.0,
-              std_dev_ratio: 0.4,
-              std_dev_ips: 800.0,
-              median: 450.0,
-              minimum: 200,
-              maximum: 900,
-              sample_size: 8
-            }
-          },
-          %Scenario{
-            job_name: "Other Job",
-            run_times: [400],
-            name: "Other Job",
-            input_name: "Some Input",
-            input: "Some Input",
-            run_time_statistics: %Benchee.Statistics{
-              average: 400.0,
-              ips: 2000.0,
-              std_dev: 200.0,
-              std_dev_ratio: 0.4,
-              std_dev_ips: 800.0,
-              median: 450.0,
-              minimum: 200,
-              maximum: 900,
-              sample_size: 8
-            }
-          },
-          %Scenario{
-            job_name: "Abakus",
-            run_times: [450],
-            name: "Abakus",
-            input_name: "Some Input",
-            input: "Some Input",
-            run_time_statistics: %Benchee.Statistics{
-              average: 450.0,
-              ips: 2000.0,
-              std_dev: 200.0,
-              std_dev_ratio: 0.4,
-              std_dev_ips: 800.0,
-              median: 450.0,
-              minimum: 200,
-              maximum: 900,
-              sample_size: 8
-            }
-          }
-        ]
-      }
-
-      data = JSON.format(suite, %{file: "my.json"})
-      decoded_result = Jason.decode!(data["Some Input"])
-      assert decoded_result["sort_order"] == ["Other Job", "Abakus", "My Job"]
-    end
-
     test "raises an exception if there is no file configured" do
       assert_raise RuntimeError, fn ->
         JSON.format(%Suite{}, %{})


### PR DESCRIPTION
Now our JSON formatter will give us memory usage statistics as well as
run time statistics.

This is a breaking change, though, so we should only release this as
1.0. I don't think it will make a whole lot of difference to do this as
a non-breaking change first. If folks want memory usage statistics, they
can upgrade to 1.0 (which they really should do anyway).